### PR TITLE
reduce position threshold for reward in sim

### DIFF
--- a/furniture_bench/config.py
+++ b/furniture_bench/config.py
@@ -90,6 +90,7 @@ config: Dict[str, Any] = {
             [-0.21, 0.21],
             [0.07, 0.37],
         ],  # Furniture parts position limits.
+        "assembled_pos_threshold": [0.010, 0.005, 0.010], # Positional threshold for declaring the furniture assembled.
         "rel_pose_from_coordinate": {
             0: get_mat([-0.03, -0.03, 0], [0, 0, 0]),
             1: get_mat([0.03, -0.03, 0], [0, 0, 0]),

--- a/furniture_bench/furniture/furniture.py
+++ b/furniture_bench/furniture/furniture.py
@@ -61,6 +61,9 @@ class Furniture(ABC):
             sum(self.max_env_steps_skills[i:])
             for i in range(len(self.max_env_steps_skills) - 1)
         ]
+        # Check whether the furniture is assembled.
+        # If the value is smaller than these thresholds, we consider the furniture is assembled.
+        self.assembled_pos_threshold = config["furniture"]["assembled_pos_threshold"]
 
     def randomize_init_pose(
         self, from_skill, pos_range=[-0.05, 0.05], rot_range=45
@@ -458,7 +461,7 @@ class Furniture(ABC):
                 assembled_rel_pose,
                 rel_pose,
                 ori_bound=ori_bound,
-                pos_threshold=[0.010, 0.005, 0.010],
+                pos_threshold=self.assembled_pos_threshold,
             ):
                 return True
 

--- a/furniture_bench/sim_config.py
+++ b/furniture_bench/sim_config.py
@@ -6,6 +6,13 @@ from furniture_bench.config import config
 
 sim_config = config.copy()
 
+
+# Positional threshold for declaring the furniture assembled.
+# This is a smaller value compared to the real-world config, since the detection can be more accurate in simulation.
+# This will reduce the false positive rate.
+sim_config["furniture"]["assembled_pos_threshold"] = [0.005, 0.005, 0.005]
+
+
 # Timeout for # environment steps for each furniture model.
 sim_config["scripted_timeout"] = {
     "one_leg": 600,


### PR DESCRIPTION
Considering the simulator's accurate pose detection compared to real-world, and the occurrence of false positive rewards in cabinet assembly, lower the threshold for reward based on position.